### PR TITLE
Fixed spelling mistake which caused function name inconsistency which pr...

### DIFF
--- a/spex.php
+++ b/spex.php
@@ -63,7 +63,7 @@ function slot() {
 	return call_user_func_array(array(spex(), __METHOD__), func_get_args());
 }
 
-function catpureSlot() {
+function captureSlot() {
 
 	return call_user_func_array(array(spex(), __METHOD__), func_get_args());
 }


### PR DESCRIPTION
...evented use of captureSlot() procedural helper
